### PR TITLE
fix(ci): add node:22 Docker container to CI workflow

### DIFF
--- a/ .github/workflows/ci.yml
+++ b/ .github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI - Node API Base
+name: CI - Node API Base (Node 22 Docker)
 
 on:
   push:
@@ -9,16 +9,11 @@ on:
 jobs:
   ci:
     runs-on: ubuntu-latest
-
+    container:
+      image: node:22
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-          cache: 'npm'
 
       - name: Install dependencies
         run: npm ci
@@ -26,7 +21,7 @@ jobs:
       - name: Run ESLint
         run: npm run lint
 
-      - name: RUN tests + coverage
+      - name: Run tests + coverage
         run: npm run test:coverage
 
       - name: Build project


### PR DESCRIPTION
### What

Use `container: image: node:22` so the CI workflow runs inside a Node.js 22 Docker container.

### Why

- `actions/setup-node` doesn’t support version 22 yet.
- Guarantees the CI environment matches Node 22.
- Prevents version mismatch between dev and CI.

### Changes

- Replaced `setup-node@v4` with Docker container in `ci.yml`.
